### PR TITLE
Add batting average to displayed stats

### DIFF
--- a/app/src/pages/PlayerStats.js
+++ b/app/src/pages/PlayerStats.js
@@ -364,6 +364,11 @@ function PlayerStats() {
       accessor: "atBats",
     },
     {
+      Header: 'AVG',
+      accessor: 'battingAverage',
+      Cell: ({value}) => parseFloat(value).toFixed(2) 
+    },
+    {
       Header: "CAUGHT STEALING",
       accessor: "caughtStealing",
     },


### PR DESCRIPTION
Batting average was being tracked in the API and the database, but not being displayed on the front end.